### PR TITLE
feat(xray): automatically restart on crashes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@
 #XRAY_ASSETS_PATH=/usr/share/xray
 #XRAY_CONFIG_PATH=/etc/xray/xray_config.json
 #XRAY_VLESS_REALITY_FLOW=xtls-rprx-vision
+#XRAY_RESTART_ON_FAILURE=False
+#XRAY_RESTART_ON_FAILURE_INTERVAL=0
 
 
 #HYSTERIA_ENABLED=False

--- a/marznode/backends/xray/_runner.py
+++ b/marznode/backends/xray/_runner.py
@@ -29,6 +29,7 @@ class XrayCore:
         self._snd_streams = []
         self._logs_buffer = deque(maxlen=100)
         self._env = {"XRAY_LOCATION_ASSET": assets_path}
+        self.stop_event = asyncio.Event()
 
         atexit.register(lambda: self.stop() if self.running else None)
 
@@ -108,6 +109,8 @@ class XrayCore:
             capture_stream(self._process.stderr), capture_stream(self._process.stdout)
         )
         logger.warning("Xray stopped/died")
+        self.stop_event.set()
+        self.stop_event.clear()
 
     def get_logs_stm(self) -> MemoryObjectReceiveStream:
         new_snd_stm, new_rcv_stm = create_memory_object_stream()

--- a/marznode/config.py
+++ b/marznode/config.py
@@ -1,8 +1,9 @@
 """loads config files from environment and env file"""
 
+from enum import Enum
+
 from decouple import config
 from dotenv import load_dotenv
-from enum import Enum
 
 load_dotenv()
 
@@ -15,7 +16,10 @@ XRAY_EXECUTABLE_PATH = config("XRAY_EXECUTABLE_PATH", default="/usr/bin/xray")
 XRAY_ASSETS_PATH = config("XRAY_ASSETS_PATH", default="/usr/share/xray")
 XRAY_CONFIG_PATH = config("XRAY_CONFIG_PATH", default="/etc/xray/config.json")
 XRAY_VLESS_REALITY_FLOW = config("XRAY_VLESS_REALITY_FLOW", default="xtls-rprx-vision")
-
+XRAY_RESTART_ON_FAILURE = config("XRAY_RESTART_ON_FAILURE", cast=bool, default=False)
+XRAY_RESTART_ON_FAILURE_INTERVAL = config(
+    "XRAY_RESTART_ON_FAILURE_INTERVAL", cast=int, default=0
+)
 
 HYSTERIA_ENABLED = config("HYSTERIA_ENABLED", cast=bool, default=False)
 HYSTERIA_EXECUTABLE_PATH = config(

--- a/marznode/storage/base.py
+++ b/marznode/storage/base.py
@@ -52,6 +52,10 @@ class BaseStorage(ABC):
         """
 
     @abstractmethod
+    async def list_inbound_users(self, tag: str) -> list[User]:
+        """returns a list of users subscribed to an inbound"""
+
+    @abstractmethod
     def register_inbound(self, inbound: Inbound) -> None:
         """
         registers a new inbound

--- a/marznode/storage/memory.py
+++ b/marznode/storage/memory.py
@@ -32,6 +32,15 @@ class MemoryStorage(BaseStorage):
             # return [i for i in self.storage["inbounds"].values() if i.tag in tag]
         return list(self.storage["inbounds"].values())
 
+    async def list_inbound_users(self, tag: str) -> list[User]:
+        users = []
+        for user in self.storage["users"].values():
+            for inbound in user.inbounds:
+                if inbound.tag == tag:
+                    users.append(user)
+                    break
+        return users
+
     async def remove_user(self, user: User) -> None:
         del self.storage["users"][user.id]
 


### PR DESCRIPTION
Adds the following environment variables:
- `XRAY_RESTART_ON_FAILURE`
- `XRAY_RESTART_ON_FAILURE_INTERVAL`

set the first one to `True` to enable automatic restarts in case xray crashes. 
manually restarting xray using the grpc api doesn't trigger this.