### PR TITLE
Issue #11

### DIFF
--- a/marznode/backends/xray/_runner.py
+++ b/marznode/backends/xray/_runner.py
@@ -44,7 +44,7 @@ class XrayCore:
 
         if "error" in config["log"]:
             try:
-                self.error_log = open(config["log"]["error"], "ab")
+                self.error_log = open(config["log"]["error"], "ab", buffering=0)
                 config["log"].pop("error")
             except OSError as e:
                 logger.error(f"Unable to open file {config['log']['error']}")

--- a/marznode/backends/xray/_runner.py
+++ b/marznode/backends/xray/_runner.py
@@ -46,7 +46,7 @@ class XrayCore:
 
         if "error" in config["log"]:
             try:
-                self.error_pipe = "/tmp/marznode_error_log"
+                self.error_pipe = "/var/lib/marznode/error_pipe"
                 if not os.path.exists(self.error_pipe):
                     os.mkfifo(self.error_pipe)
                 self.error_log = open(config["log"]["error"], mode="ab", buffering=0)


### PR DESCRIPTION
Added the ability to save error.log to a file without disrupting the functionality of the rest of the program

It is recommended to save error.log in /var/lib/marznode