### PR TITLE
fix(sing-box): null transport by default

### DIFF
--- a/marznode/backends/singbox/_config.py
+++ b/marznode/backends/singbox/_config.py
@@ -59,7 +59,7 @@ class SingBoxConfig(dict):
                 "tag": inbound["tag"],
                 "protocol": inbound["type"],
                 "port": inbound.get("listen_port"),
-                "network": "tcp",
+                "network": None,
                 "tls": "none",
                 "sni": [],
                 "host": [],

--- a/marznode/backends/singbox/_config.py
+++ b/marznode/backends/singbox/_config.py
@@ -96,6 +96,9 @@ class SingBoxConfig(dict):
                 elif settings["network"] == "httpupgrade":
                     settings["path"] = inbound["transport"].get("path")
 
+            if inbound["type"] == "shadowtls" and "version" in inbound:
+                settings["shadowtls_version"] = inbound["version"]
+
             self.inbounds.append(settings)
             self.inbounds_by_tag[inbound["tag"]] = settings
 

--- a/marznode/backends/singbox/_config.py
+++ b/marznode/backends/singbox/_config.py
@@ -52,6 +52,7 @@ class SingBoxConfig(dict):
                 "vless",
                 "hysteria2",
                 "tuic",
+                "shadowtls",
             } or not inbound.get("tag"):
                 continue
 


### PR DESCRIPTION
Set network to null when parsing sing-box config, to prevent problems with tuic/shadowtls protocols. 
Also parse shadowtls version correctly